### PR TITLE
Update .env.development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-API_ROOT=http://localhost:8000/api
+API_ROOT=/api
 NODE_ENV=development


### PR DESCRIPTION
The hardcoded localhost:8000 should be removed because it makes the API endpoints inaccessible if the port or URL changes. In the current setup, for example, the port is 3000, which prevents the APIs from being fetched.